### PR TITLE
remove temp file after use

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -379,6 +379,7 @@ func (w *writerOnce) initFile() error {
 	w.file = file
 	w.cleanupFn = func() error {
 		file.Close()
+		os.Remove(file.Name())
 		return nil
 	}
 	return nil


### PR DESCRIPTION
/tmp was filling up when using vulcand. I suspect this is the fix, although I haven't proved that yet.
